### PR TITLE
Scrum253and254 - PAC projection front end overhaul

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -36,7 +36,7 @@ function App() {
   return (
     <div>
       <NavBar />
-      <Box sx={{ mt: '64px', ml: '240px', p: 3 }}>
+      <Box sx={{top: '40px', marginLeft: '80px'}}>
         <Outlet />
       </Box>
     </div>

--- a/client/src/pages/pac/pac.js
+++ b/client/src/pages/pac/pac.js
@@ -335,15 +335,15 @@ const PAC = () => {
   const [actualData, setActualData] = useState({}); // Will hold actual data from invoices
   const [hoverInfo, setHoverInfo] = useState(null);
 
-// Categories for visual grouping
-const categories = {
-  'Sales': ['Sales', 'All Net Sales'],
-  'Food & Paper': ['Base Food', 'Employee Meal', 'Condiment', 'Total Waste', 'Paper'],
-  'Labor': ['Crew Labor', 'Management Labor', 'Payroll Tax'],
-  'Purchases': ['Advertising', 'Travel', 'Adv Other', 'Promotion', 'Outside Services',
-                'Linen', 'OP. Supply', 'Maint. & Repair', 'Small Equipment', 
-                'Utilities', 'Office', 'Cash +/-', 'Misc: CR/TR/D&S']
-};
+  // Categories for visual grouping
+  const categories = {
+    'Sales': ['Sales', 'All Net Sales'],
+    'Food & Paper': ['Base Food', 'Employee Meal', 'Condiment', 'Total Waste', 'Paper'],
+    'Labor': ['Crew Labor', 'Management Labor', 'Payroll Tax'],
+    'Purchases': ['Advertising', 'Travel', 'Adv Other', 'Promotion', 'Outside Services',
+                  'Linen', 'OP. Supply', 'Maint. & Repair', 'Small Equipment', 
+                  'Utilities', 'Office', 'Cash +/-', 'Misc: CR/TR/D&S']
+  };
 
   // Calculate category sums
   const calculateCategorySums = (data, type) => {

--- a/client/src/pages/pac/pac.js
+++ b/client/src/pages/pac/pac.js
@@ -592,6 +592,17 @@ const PAC = () => {
             </Grid>
           </Grid>
         </Paper>
+
+        <div className="pac-goal-container">
+          <TextField
+            label="PAC Goal ($)"
+            size="small"
+            variant="outlined"
+            className="pac-goal-input"
+            value={pacGoal}
+            onChange={(e)=>setPacGoal(e.target.value)}
+          />
+        </div>
       </Container>
 
       {tabIndex === 0 && (


### PR DESCRIPTION
and fixed a layout issue in App.js that was caused by a previous commit that had old code.

Main items:

Moved the apply button from page navigation bar to the bottom of projection tab
Correctly applied container components to prevent ui sizing issues.
Color coded each expense item
User input is now limited to specific expenses and projection amount/percent.
Redid page navigation bar to now fluidly resize and arrange based on window size. Things on the left will now not clip past the window.
Deleted '%' from being stored with the percentage value.