### PR TITLE
Enhance invoice logs and PAC components with month locking functionality

### DIFF
--- a/client/src/pages/pac/PacTab.js
+++ b/client/src/pages/pac/PacTab.js
@@ -144,6 +144,12 @@ const printStyles = `
       display: none !important;
     }
     
+    .print-status, .print-timestamp {
+      font-size: 10px;
+      margin: 5px 0;
+      page-break-after: avoid;
+    }
+    
     /* Ensure content fits on one page */
     .print-table {
       page-break-inside: avoid;
@@ -164,7 +170,15 @@ const printStyles = `
   }
 `;
 
-const PacTab = ({ storeId, year, month, projections = [] }) => {
+const PacTab = ({
+  storeId,
+  year,
+  month,
+  projections = [],
+  isMonthLocked = false,
+  monthLockStatus = null,
+  lastUpdatedTimestamp = null,
+}) => {
   const [pacData, setPacData] = useState(null);
   const [projectionsData, setProjectionsData] = useState(null);
 
@@ -199,7 +213,7 @@ const PacTab = ({ storeId, year, month, projections = [] }) => {
 
     const getProjectedValueAsNumber = (expenseName) => {
       if (!projectionsData) return 0;
-      
+
       // Map expense names to the correct backend field structure
       const expenseMap = {
         "Product Net Sales": projectionsData.product_net_sales,
@@ -210,18 +224,23 @@ const PacTab = ({ storeId, year, month, projections = [] }) => {
         "Total Waste": projectionsData.controllable_expenses?.total_waste,
         Paper: projectionsData.controllable_expenses?.paper,
         "Crew Labor": projectionsData.controllable_expenses?.crew_labor,
-        "Management Labor": projectionsData.controllable_expenses?.management_labor,
+        "Management Labor":
+          projectionsData.controllable_expenses?.management_labor,
         "Payroll Tax": projectionsData.controllable_expenses?.payroll_tax,
         Travel: projectionsData.controllable_expenses?.travel,
         Advertising: projectionsData.controllable_expenses?.advertising,
-        "Advertising Other": projectionsData.controllable_expenses?.advertising_other,
+        "Advertising Other":
+          projectionsData.controllable_expenses?.advertising_other,
         "Adv Other": projectionsData.controllable_expenses?.advertising_other, // Alternative naming
         Promotion: projectionsData.controllable_expenses?.promotion,
-        "Outside Services": projectionsData.controllable_expenses?.outside_services,
+        "Outside Services":
+          projectionsData.controllable_expenses?.outside_services,
         Linen: projectionsData.controllable_expenses?.linen,
         "Operating Supply": projectionsData.controllable_expenses?.op_supply,
-        "Maintenance & Repair": projectionsData.controllable_expenses?.maintenance_repair,
-        "Small Equipment": projectionsData.controllable_expenses?.small_equipment,
+        "Maintenance & Repair":
+          projectionsData.controllable_expenses?.maintenance_repair,
+        "Small Equipment":
+          projectionsData.controllable_expenses?.small_equipment,
         Utilities: projectionsData.controllable_expenses?.utilities,
         Office: projectionsData.controllable_expenses?.office,
         "Cash +/-": projectionsData.controllable_expenses?.cash_adjustments,
@@ -229,25 +248,25 @@ const PacTab = ({ storeId, year, month, projections = [] }) => {
         "Total Controllable": projectionsData.total_controllable_dollars,
         "P.A.C.": projectionsData.pac_dollars,
       };
-      
+
       const expenseData = expenseMap[expenseName];
       if (!expenseData) return 0;
-      
+
       // Handle different data structures
-      if (typeof expenseData === 'number') {
+      if (typeof expenseData === "number") {
         // Direct number (for sales, totals, P.A.C.)
         return expenseData;
-      } else if (expenseData && typeof expenseData === 'object') {
+      } else if (expenseData && typeof expenseData === "object") {
         // Object with dollars/percent structure
         return parseFloat(expenseData.dollars || 0);
       }
-      
+
       return 0;
     };
 
     const getProjectedValue = (expenseName, type) => {
       if (!projectionsData) return "-";
-      
+
       // Map expense names to the correct backend field structure
       const expenseMap = {
         "Product Net Sales": projectionsData.product_net_sales,
@@ -258,18 +277,23 @@ const PacTab = ({ storeId, year, month, projections = [] }) => {
         "Total Waste": projectionsData.controllable_expenses?.total_waste,
         Paper: projectionsData.controllable_expenses?.paper,
         "Crew Labor": projectionsData.controllable_expenses?.crew_labor,
-        "Management Labor": projectionsData.controllable_expenses?.management_labor,
+        "Management Labor":
+          projectionsData.controllable_expenses?.management_labor,
         "Payroll Tax": projectionsData.controllable_expenses?.payroll_tax,
         Travel: projectionsData.controllable_expenses?.travel,
         Advertising: projectionsData.controllable_expenses?.advertising,
-        "Advertising Other": projectionsData.controllable_expenses?.advertising_other,
+        "Advertising Other":
+          projectionsData.controllable_expenses?.advertising_other,
         "Adv Other": projectionsData.controllable_expenses?.advertising_other, // Alternative naming
         Promotion: projectionsData.controllable_expenses?.promotion,
-        "Outside Services": projectionsData.controllable_expenses?.outside_services,
+        "Outside Services":
+          projectionsData.controllable_expenses?.outside_services,
         Linen: projectionsData.controllable_expenses?.linen,
         "Operating Supply": projectionsData.controllable_expenses?.op_supply,
-        "Maintenance & Repair": projectionsData.controllable_expenses?.maintenance_repair,
-        "Small Equipment": projectionsData.controllable_expenses?.small_equipment,
+        "Maintenance & Repair":
+          projectionsData.controllable_expenses?.maintenance_repair,
+        "Small Equipment":
+          projectionsData.controllable_expenses?.small_equipment,
         Utilities: projectionsData.controllable_expenses?.utilities,
         Office: projectionsData.controllable_expenses?.office,
         "Cash +/-": projectionsData.controllable_expenses?.cash_adjustments,
@@ -277,35 +301,41 @@ const PacTab = ({ storeId, year, month, projections = [] }) => {
         "Total Controllable": projectionsData.total_controllable_dollars,
         "P.A.C.": projectionsData.pac_dollars,
       };
-      
+
       const expenseData = expenseMap[expenseName];
       if (!expenseData) return "-";
-      
+
       // Handle different data structures
       let value;
-      if (typeof expenseData === 'number') {
+      if (typeof expenseData === "number") {
         // Direct number (for sales, totals, P.A.C.)
         value = expenseData;
-      } else if (expenseData && typeof expenseData === 'object') {
+      } else if (expenseData && typeof expenseData === "object") {
         // Object with dollars/percent structure
         value = expenseData.dollars;
       } else {
         return "-";
       }
-      
+
       if (value === null || value === undefined) return "-";
-      
+
       if (type === "dollar") {
         return formatCurrency(parseFloat(value));
       } else if (type === "percent") {
         // For percentage, use the percent from the object if available, otherwise calculate
-        if (expenseData && typeof expenseData === 'object' && expenseData.percent !== undefined) {
+        if (
+          expenseData &&
+          typeof expenseData === "object" &&
+          expenseData.percent !== undefined
+        ) {
           return formatPercentage(expenseData.percent);
         } else {
           // Calculate percentage based on net sales
-          const projectedNetSales = projectionsData.product_net_sales || projectionsData.all_net_sales;
+          const projectedNetSales =
+            projectionsData.product_net_sales || projectionsData.all_net_sales;
           if (!projectedNetSales || projectedNetSales === 0) return "-";
-          const percentage = (parseFloat(value) / parseFloat(projectedNetSales)) * 100;
+          const percentage =
+            (parseFloat(value) / parseFloat(projectedNetSales)) * 100;
           return formatPercentage(percentage);
         }
       }
@@ -355,10 +385,24 @@ const PacTab = ({ storeId, year, month, projections = [] }) => {
       return diff < 0 ? "text-red" : diff > 0 ? "text-green" : "";
     };
 
+    // Generate status information for print
+    let statusInfo = "";
+    if (isMonthLocked) {
+      statusInfo += `<div class="print-status" style="text-align: center; margin-bottom: 10px; padding: 5px; background-color: #fff3cd; border: 1px solid #ffeaa7; color: #856404; font-weight: bold;">
+        🔒 Month Locked by ${monthLockStatus?.locked_by || "Unknown"}
+      </div>`;
+    }
+    if (lastUpdatedTimestamp) {
+      statusInfo += `<div class="print-timestamp" style="text-align: center; margin-bottom: 10px; padding: 5px; background-color: #d1ecf1; border: 1px solid #bee5eb; color: #0c5460; font-weight: bold;">
+        Last Updated: ${lastUpdatedTimestamp.toLocaleString()}
+      </div>`;
+    }
+
     return `
       <div class="print-header">
         PAC Report - ${storeId} - ${month} ${year}
       </div>
+      ${statusInfo}
       <table class="print-table">
         <thead>
           <tr>

--- a/client/src/pages/pac/pac.js
+++ b/client/src/pages/pac/pac.js
@@ -1010,7 +1010,12 @@ const PAC = () => {
                         <TextField
                           size="small"
                           variant="outlined"
-                          sx={{ width: "150px", backgroundColor: "#ffffff" }}
+                          sx={{
+                            width: "150px",
+                            backgroundColor: isMonthLocked()
+                              ? "#f5f5f5"
+                              : "#ffffff",
+                          }}
                           slotProps={{
                             input: {
                               startAdornment: (
@@ -1028,6 +1033,7 @@ const PAC = () => {
                               e.target.value
                             )
                           }
+                          disabled={isMonthLocked()}
                         />
                       ) : (
                         <item>${expense.projectedDollar || "0.00"}</item>
@@ -1043,7 +1049,12 @@ const PAC = () => {
                           <TextField
                             size="small"
                             variant="outlined"
-                            sx={{ width: "125px", backgroundColor: "#ffffff" }}
+                            sx={{
+                              width: "125px",
+                              backgroundColor: isMonthLocked()
+                                ? "#f5f5f5"
+                                : "#ffffff",
+                            }}
                             slotProps={{
                               input: {
                                 endAdornment: (
@@ -1061,6 +1072,7 @@ const PAC = () => {
                                 e.target.value
                               )
                             }
+                            disabled={isMonthLocked()}
                           />
                         ) : (
                           <item>{expense.projectedPercent || "0"}%</item>
@@ -1101,7 +1113,19 @@ const PAC = () => {
             textAlign="center"
             sx={{ paddingTop: "10px", paddingBottom: "10px" }}
           >
-            <Button variant="contained" size="large" onClick={handleApply}>
+            <Button
+              variant="contained"
+              size="large"
+              onClick={handleApply}
+              disabled={isMonthLocked()}
+              sx={{
+                backgroundColor: isMonthLocked() ? "#f5f5f5" : "#1976d2",
+                color: isMonthLocked() ? "#999999" : "white",
+                "&:hover": {
+                  backgroundColor: isMonthLocked() ? "#f5f5f5" : "#42a5f5",
+                },
+              }}
+            >
               Apply
             </Button>
           </Box>
@@ -1461,6 +1485,8 @@ const PAC = () => {
             month={month}
             projections={projections}
             isMonthLocked={isMonthLocked()}
+            monthLockStatus={monthLockStatus}
+            lastUpdatedTimestamp={lastUpdatedTimestamp}
           />
         </Container>
       )}{" "}

--- a/client/src/pages/submitInvoice/submitInvoice.js
+++ b/client/src/pages/submitInvoice/submitInvoice.js
@@ -444,6 +444,7 @@ const SubmitInvoice = () => {
               onChange={(e) => setInvoiceDate(new Date(e.target.value))}
               size="small"
               sx={{ width: "100%" }}
+              disabled={isMonthLocked()}
               InputLabelProps={{
                 shrink: true,
               }}
@@ -461,7 +462,6 @@ const SubmitInvoice = () => {
                   value={targetMonth}
                   onChange={(e) => setTargetMonth(e.target.value)}
                   label="Month"
-                  disabled={isMonthLocked()}
                 >
                   {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => {
                     const monthNames = [
@@ -507,7 +507,6 @@ const SubmitInvoice = () => {
                   value={targetYear}
                   onChange={(e) => setTargetYear(e.target.value)}
                   label="Year"
-                  disabled={isMonthLocked()}
                 >
                   {Array.from(
                     { length: 11 },
@@ -531,7 +530,7 @@ const SubmitInvoice = () => {
             <div key={idx} className={styles.extraRow}>
               <select
                 value={row.category}
-                disabled={row.confirmed}
+                disabled={row.confirmed || isMonthLocked()}
                 onChange={(e) => {
                   const val = e.target.value;
                   setExtras((prev) =>
@@ -557,7 +556,7 @@ const SubmitInvoice = () => {
                   type="text"
                   placeholder="Amount"
                   value={row.amount}
-                  disabled={row.confirmed}
+                  disabled={row.confirmed || isMonthLocked()}
                   onChange={(e) => {
                     const val = e.target.value;
                     setExtras((prev) =>
@@ -569,7 +568,7 @@ const SubmitInvoice = () => {
                 />
                 {row.confirmed && <span className={styles.checkmark}>✓</span>}
               </div>
-              {!row.confirmed && (
+              {!row.confirmed && !isMonthLocked() && (
                 <button
                   type="button"
                   className={styles.confirmBtn}
@@ -578,18 +577,25 @@ const SubmitInvoice = () => {
                   Confirm
                 </button>
               )}
-              <button
-                type="button"
-                className={styles.removeBtn}
-                onClick={() => handleRemove(idx)}
-              >
-                Remove
-              </button>
+              {!isMonthLocked() && (
+                <button
+                  type="button"
+                  className={styles.removeBtn}
+                  onClick={() => handleRemove(idx)}
+                >
+                  Remove
+                </button>
+              )}
             </div>
           ))}
 
           <div className={styles.formGroup}>
-            <button type="button" className={styles.addBtn} onClick={handleAdd}>
+            <button
+              type="button"
+              className={styles.addBtn}
+              onClick={handleAdd}
+              disabled={isMonthLocked()}
+            >
               + Add New Amount
             </button>
           </div>
@@ -598,6 +604,7 @@ const SubmitInvoice = () => {
             <input
               type="file"
               onChange={(e) => setImageUpload(e.target.files[0])}
+              disabled={isMonthLocked()}
             />
             <button
               type="submit"
@@ -612,7 +619,7 @@ const SubmitInvoice = () => {
               type="button"
               className={styles.readUploadBtn}
               onClick={handleReadFromUpload}
-              disabled={loadingUpload}
+              disabled={loadingUpload || isMonthLocked()}
             >
               {loadingUpload ? "Reading..." : "Read from Upload"}
             </button>

--- a/server/python_backend/routers.py
+++ b/server/python_backend/routers.py
@@ -153,6 +153,8 @@ async def submit_invoice(
     invoice_day: int = Form(...),
     invoice_month: int = Form(...),
     invoice_year: int = Form(...),
+    target_month: int = Form(...),
+    target_year: int = Form(...),
     store_id: str = Form(...),
     user_email: str = Form(...),
     categories: str = Form(...),  # JSON string of categories
@@ -188,6 +190,8 @@ async def submit_invoice(
             validation_errors.append("Company name is required")
         if not invoice_day or not invoice_month or not invoice_year:
             validation_errors.append("Invoice date (day, month, year) is required")
+        if not target_month or not target_year:
+            validation_errors.append("Target month/year is required")
         if not store_id:
             validation_errors.append("Store ID is required")
         if not user_email:
@@ -220,6 +224,8 @@ async def submit_invoice(
             'invoiceNumber': invoice_number,
             'companyName': company_name,
             'invoiceDate': invoice_date,
+            'targetMonth': target_month,
+            'targetYear': target_year,
             'storeID': store_id,
             'user_email': user_email,
             'categories': categories_dict,

--- a/server/python_backend/services/invoice_submit.py
+++ b/server/python_backend/services/invoice_submit.py
@@ -99,6 +99,8 @@ class InvoiceSubmitService:
                 'imageURL': image_url,
                 'invoiceDate': invoice_data.get('invoiceDate', ''),
                 'invoiceNumber': invoice_data.get('invoiceNumber', ''),
+                'targetMonth': invoice_data.get('targetMonth', ''),
+                'targetYear': invoice_data.get('targetYear', ''),
                 'storeID': invoice_data.get('storeID', ''),
                 'user_email': invoice_data.get('user_email', '')
             }


### PR DESCRIPTION
- Updated invoice logs to filter and display invoices based on selected month and year, incorporating target month/year for grouping.
- Added debug logging for fetched and filtered invoices to assist in troubleshooting.
- Enhanced PAC components to disable inputs and buttons when the month is locked, ensuring no modifications can be made.
- Introduced target month/year selection in the submit invoice form, with validation for required fields.
- Updated backend to handle target month/year during invoice submission, ensuring data integrity across the application.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds target month/year support across invoice submission and logs, enhances PAC with lock/timestamp print status, and enforces month locks in UI and backend.
> 
> - **Frontend**:
>   - **Invoice Logs (`client/src/pages/invoiceLogs/invoiceLogs.js`)**:
>     - Use `targetMonth/targetYear` for filtering/grouping; add Month/Year column; compute totals on filtered invoices.
>     - Disable Edit/Delete/Lock/Unlock actions when the invoice’s month is locked; show locked-month banner in header.
>     - Edit dialog: add `targetMonth/targetYear` selectors; persist on save.
>     - Budget fetch: align to `pac-projections` and projection name map; expand effect deps; minor UI widths/colspans; add debug logs.
>   - **Submit Invoice (`client/src/pages/submitInvoice/submitInvoice.js`)**:
>     - Add target month/year selectors; block inputs/actions (incl. file/read/confirm/remove/add) when selected month is locked.
>     - Include `target_month/target_year` in POST body; lock warning banner.
>   - **PAC**:
>     - `PacTab.js`: extend props with `isMonthLocked`, `monthLockStatus`, `lastUpdatedTimestamp`; inject lock/timestamp status into print output; print style tweaks.
>     - `pac.js`: pass `monthLockStatus` and `lastUpdatedTimestamp` to `PacTab`.
> - **Backend**:
>   - `routers.py`: `/invoices/submit` accepts and validates `target_month/target_year`; include in saved invoice payload.
>   - `services/invoice_submit.py`: persist `targetMonth/targetYear` in Firestore invoice docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0021e53032d6fbff0fecaa3b4f704b4b4e57c741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->